### PR TITLE
Fix nonexhaustive switch breaking compilation with swift-syntax-binary

### DIFF
--- a/Sources/DependenciesMacrosPlugin/DependencyClientMacro.swift
+++ b/Sources/DependenciesMacrosPlugin/DependencyClientMacro.swift
@@ -120,6 +120,8 @@ public enum DependencyClientMacro: MemberAttributeMacro, MemberMacro {
           if accessors.contains(where: { $0.accessorSpecifier.tokenKind == .keyword(.get) }) {
             continue
           }
+        default:
+          break
         }
       }
 


### PR DESCRIPTION
The fix is required to enable _swift-dependencies_ to be used with the prebuilt version of _swift-syntax_. Compilation breaks on `DependencyClientMacro:116:9` with `Switch covers known cases, but 'AccessorBlockSyntax.Accessors' may have additional unknown values` error message. It is necessary to define [exhaustive switch cases](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0192-non-exhaustive-enums.md) for unfrozen enums because compilation, unaware of possible enum changes due to ABI stability, returns an error instead of a warning, unlike compilation from sources.